### PR TITLE
findBy() 추가

### DIFF
--- a/src/main/java/harmony/dev/harmonyserver/repository/MemberRepository.java
+++ b/src/main/java/harmony/dev/harmonyserver/repository/MemberRepository.java
@@ -3,10 +3,23 @@ package harmony.dev.harmonyserver.repository;
 import harmony.dev.harmonyserver.domain.Member;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MemberRepository {
     Member save(Member member);
     List<Member> findByOptionalParameters(String userId, String phoneNumber);
     List<Member> findByUserId(String userId);
     List<Member> findByPhoneNumber(String phoneNumber);
+
+    interface FindBy {
+        List<Member> toList();
+        Optional<Member> toOptional();
+        boolean isEmpty();
+
+        // Setter with method chaining
+        FindBy userId(String userId);
+        FindBy password(String password);
+        FindBy phoneNumber(String phoneNumber);
+    }
+    FindBy findBy();
 }


### PR DESCRIPTION
- #11 

builder 패턴과 유사한 형태로 사용이 가능한 `findBy()`가 추가됩니다.

### 사용 예시
- 결과가 1개 이하인 경우(unique field 사용해 검색하는 경우)
```java
memberRepository.findBy()
                .userId("namsic")
                .toOptional()
```
- 검색 결과가 n개일 수 있는 경우
```java
memberRepository.findBy()
                .nickname("superstarNJK")
                .toList() 
```
- 결과 유무 확인
```java
memberRepository.findBy()
                .userId("namsic")
                .password("1234")
                .isEmpty()
```